### PR TITLE
Filters Update

### DIFF
--- a/debug.xml
+++ b/debug.xml
@@ -34,7 +34,7 @@
 
     <entry key='filter.enable'>true</entry>
     <entry key='filter.zero'>true</entry>
-    <!-- <entry key='filter.distance'>20</entry> -->
+     <entry key='filter.distance'>20</entry>
     <!-- <entry key='filter.maxSpeed'>25000</entry> -->
     <!-- <entry key='filter.invalid'>true</entry> -->
     <!-- <entry key='filter.duplicate'>true</entry> -->
@@ -44,6 +44,7 @@
 
     <entry key='filter.ignoreDistanceForTeltonika'>true</entry>
     <entry key='filter.distanceWhenIgnitionOff'>20</entry>
+    <entry key='filter.distanceWhenIgnitionOffDevices'>230,654,1179</entry>
 
     <entry key='report.ignoreOdometer'>false</entry>
 </properties>

--- a/src/main/java/org/traccar/config/Keys.java
+++ b/src/main/java/org/traccar/config/Keys.java
@@ -1439,10 +1439,17 @@ public final class Keys {
 
     /**
      * Distance filter when ignition is off. If this is mentioned along with `filter.distance` and ignition is off, then
-     * this distance will be considered for filtering.
+     * this distance will be considered for filtering. Applies only to devices that are not mentioned in `filter.distanceWhenIgnitionOffDevices`.
      */
     public static final ConfigKey<Integer> FILTER_DISTANCE_WHEN_IGNITION_OFF = new IntegerConfigKey(
             "filter.distanceWhenIgnitionOff",
+            List.of(KeyType.CONFIG));
+
+    /**
+     * List of devices (csv) for which distance filter should be ignored when ignition is off.
+     */
+    public static final ConfigKey<String> FILTER_DISTANCE_WHEN_IGNITION_OFF_DEVICES = new StringConfigKey(
+            "filter.distanceWhenIgnitionOffDevices",
             List.of(KeyType.CONFIG));
 
     // * CUSTOM CODE END * //

--- a/src/main/java/org/traccar/handler/FilterHandler.java
+++ b/src/main/java/org/traccar/handler/FilterHandler.java
@@ -65,6 +65,7 @@ public class FilterHandler extends BasePositionHandler {
     private final StatisticsManager statisticsManager;
     // * CUSTOM CODE START * //
     private final boolean filterIgnoreDistanceForTeltonika;
+    private final int[] deviceIds;
     // * CUSTOM CODE END * //
 
     @Inject
@@ -93,6 +94,14 @@ public class FilterHandler extends BasePositionHandler {
         // * CUSTOM CODE START * //
         // parameter used to ignore distance filter for `Teltonika` model devices
         filterIgnoreDistanceForTeltonika = config.getBoolean(Keys.FILTER_IGNORE_DISTANCE_FOR_TELTONIKA);
+
+        var devices = filterDistanceWhenIgnitionOffDevices.split(",");
+
+        deviceIds = new int[devices.length];
+        for (int i = 0; i < devices.length; i++) {
+            deviceIds[i] = Integer.parseInt(devices[i]);
+        }
+
         // * CUSTOM CODE END * //
 
         this.cacheManager = cacheManager;
@@ -181,15 +190,6 @@ public class FilterHandler extends BasePositionHandler {
         if (!position.getBoolean(Position.KEY_IGNITION) && filterDistanceWhenIgnitionOff != 0 && last != null) {
             // Get the device data using the deviceId in the position
             Device device = cacheManager.getObject(Device.class, position.getDeviceId());
-
-            // Get devices we need to ignore.
-            String[] devices = filterDistanceWhenIgnitionOffDevices.split(",");
-
-            int[] deviceIds = new int[devices.length];
-
-            for (int i = 0; i < devices.length; i++) {
-                deviceIds[i] = Integer.parseInt(devices[i]);
-            }
 
             for (int deviceId : deviceIds) {
                 // Apply special ignition off distance filter if the device is in the list

--- a/src/main/java/org/traccar/handler/FilterHandler.java
+++ b/src/main/java/org/traccar/handler/FilterHandler.java
@@ -51,6 +51,7 @@ public class FilterHandler extends BasePositionHandler {
     private final boolean filterStatic;
     private final int filterDistance;
     private final int filterDistanceWhenIgnitionOff;
+    private final String filterDistanceWhenIgnitionOffDevices;
     private final int filterMaxSpeed;
     private final long filterMinPeriod;
     private final int filterDailyLimit;
@@ -80,6 +81,7 @@ public class FilterHandler extends BasePositionHandler {
         filterStatic = config.getBoolean(Keys.FILTER_STATIC);
         filterDistance = config.getInteger(Keys.FILTER_DISTANCE);
         filterDistanceWhenIgnitionOff = config.getInteger(Keys.FILTER_DISTANCE_WHEN_IGNITION_OFF);
+        filterDistanceWhenIgnitionOffDevices = config.getString(Keys.FILTER_DISTANCE_WHEN_IGNITION_OFF_DEVICES);
         filterMaxSpeed = config.getInteger(Keys.FILTER_MAX_SPEED);
         filterMinPeriod = config.getInteger(Keys.FILTER_MIN_PERIOD) * 1000L;
         filterDailyLimit = config.getInteger(Keys.FILTER_DAILY_LIMIT);
@@ -177,7 +179,24 @@ public class FilterHandler extends BasePositionHandler {
         }
 
         if (!position.getBoolean(Position.KEY_IGNITION) && filterDistanceWhenIgnitionOff != 0 && last != null) {
-            return position.getDouble(Position.KEY_DISTANCE) < filterDistanceWhenIgnitionOff;
+            // Get the device data using the deviceId in the position
+            Device device = cacheManager.getObject(Device.class, position.getDeviceId());
+
+            // Get devices we need to ignore.
+            String[] devices = filterDistanceWhenIgnitionOffDevices.split(",");
+
+            int[] deviceIds = new int[devices.length];
+
+            for (int i = 0; i < devices.length; i++) {
+                deviceIds[i] = Integer.parseInt(devices[i]);
+            }
+
+            for (int deviceId : deviceIds) {
+                // Apply special ignition off distance filter if the device is in the list
+                if (deviceId == device.getId()) {
+                    return position.getDouble(Position.KEY_DISTANCE) < filterDistanceWhenIgnitionOff;
+                }
+            }
         }
 
         // * CUSTOM CODE END * //
@@ -237,10 +256,25 @@ public class FilterHandler extends BasePositionHandler {
 
         StringBuilder filterType = new StringBuilder();
 
+        long deviceId = position.getDeviceId();
+        Device device = cacheManager.getObject(Device.class, deviceId);
+
         // filter out invalid data
         if (filterInvalid(position)) {
             filterType.append("Invalid ");
         }
+
+        // * CUSTOM CODE START * //
+
+        // if the new position's ignition status is not same as the last known ignition status, let it pass without any filtering
+        Position last = cacheManager.getPosition(deviceId);
+
+        if (last != null && last.getBoolean(Position.KEY_IGNITION) != position.getBoolean(Position.KEY_IGNITION)) {
+            return false;
+        }
+
+        // * CUSTOM CODE END * //
+
         if (filterZero(position)) {
             filterType.append("Zero ");
         }
@@ -261,7 +295,6 @@ public class FilterHandler extends BasePositionHandler {
         }
 
         // filter out excessive data
-        long deviceId = position.getDeviceId();
         if (filterDuplicate || filterStatic
                 || filterDistance > 0 || filterMaxSpeed > 0 || filterMinPeriod > 0 || filterDailyLimit > 0) {
             Position preceding;
@@ -296,7 +329,6 @@ public class FilterHandler extends BasePositionHandler {
             }
         }
 
-        Device device = cacheManager.getObject(Device.class, deviceId);
         if (device.getCalendarId() > 0) {
             Calendar calendar = cacheManager.getObject(Calendar.class, device.getCalendarId());
             if (!calendar.checkMoment(position.getFixTime())) {


### PR DESCRIPTION
- Added new `filter.distanceWhenIgnitionOffDevices` config key to restrict the ignition off distance filter to only these devices.
- Updated filtering code to let ignition change events escape even if they are not qualified via skip limit exceeding. 