### PR TITLE
Docker Compose & DockerFile Setup

### DIFF
--- a/traccar-docker/Dockerfile
+++ b/traccar-docker/Dockerfile
@@ -1,0 +1,95 @@
+# Stage 1: Build environment
+FROM openjdk:11-jdk-slim as builder
+
+# Set environment variables
+ENV BRANCH_NAME=version-6.2
+ENV TRACCAR_HOME=/opt/traccar
+
+# Install required packages
+RUN apt-get update && \
+    apt-get install -y git unzip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Clone specific repository and branch
+WORKDIR $TRACCAR_HOME
+RUN git clone -b version-6.2 https://github.com/BunnyMan1/traccar.git . && \
+    git checkout version-6.2
+
+# Build with Gradle
+RUN chmod +x ./gradlew
+RUN ./gradlew clean build
+
+# Stage 2: Runtime environment
+FROM openjdk:11-jre-slim
+
+# Set environment variables
+ENV TRACCAR_HOME=/opt/traccar
+
+# Install required packages for runtime
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    default-mysql-client && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create necessary directories
+RUN mkdir -p /opt/traccar/logs \
+    /opt/traccar/data \
+    /opt/traccar/conf \
+    /opt/traccar/lib \
+    /opt/traccar/traccar-web \
+    /opt/traccar/target/media
+
+# Copy built application from builder stage
+COPY --from=builder $TRACCAR_HOME/target $TRACCAR_HOME/target/
+COPY --from=builder $TRACCAR_HOME/schema $TRACCAR_HOME/schema
+COPY --from=builder $TRACCAR_HOME/traccar-web $TRACCAR_HOME/traccar-web
+COPY --from=builder $TRACCAR_HOME/target/lib $TRACCAR_HOME/lib/
+COPY --from=builder $TRACCAR_HOME/target/tracker-server.jar $TRACCAR_HOME/tracker-server.jar
+
+# Create MySQL configuration
+RUN echo '<?xml version="1.0"?>\n\
+    <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">\n\
+    <properties>\n\
+    <entry key="database.driver">com.mysql.cj.jdbc.Driver</entry>\n\
+    <entry key="database.url">jdbc:mysql://${MYSQL_HOST}:3306/${MYSQL_DATABASE}?allowPublicKeyRetrieval=true&amp;useSSL=false&amp;allowMultiQueries=true&amp;autoReconnect=true&amp;useUnicode=yes&amp;characterEncoding=UTF-8&amp;sessionVariables=sql_mode=NO_ENGINE_SUBSTITUTION</entry>\n\
+    <entry key="database.user">${MYSQL_USER}</entry>\n\
+    <entry key="database.password">${MYSQL_PASSWORD}</entry>\n\
+    <entry key="web.path">/opt/traccar/traccar-web/simple</entry>\n\
+    <entry key="web.debug">true</entry>\n\
+    <entry key="web.console">true</entry>\n\
+    <entry key="media.path">/opt/traccar/target/media</entry>\n\
+    <entry key="logger.console">true</entry>\n\
+    <entry key="logger.queries">false</entry>\n\
+    <entry key="logger.fullStackTraces">true</entry>\n\
+    </properties>' > /opt/traccar/conf/traccar.xml
+
+# Create startup script
+RUN echo '#!/bin/sh\n\
+    # Wait for MySQL to be ready\n\
+    while ! mysql -h "$MYSQL_HOST" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" -e "SELECT 1" >/dev/null 2>&1; do\n\
+    echo "Waiting for MySQL..."\n\
+    sleep 1\n\
+    done\n\
+    \n\
+    # Replace environment variables in config\n\
+    sed -i "s/\${MYSQL_HOST}/$MYSQL_HOST/g" /opt/traccar/conf/traccar.xml\n\
+    sed -i "s/\${MYSQL_DATABASE}/$MYSQL_DATABASE/g" /opt/traccar/conf/traccar.xml\n\
+    sed -i "s/\${MYSQL_USER}/$MYSQL_USER/g" /opt/traccar/conf/traccar.xml\n\
+    sed -i "s/\${MYSQL_PASSWORD}/$MYSQL_PASSWORD/g" /opt/traccar/conf/traccar.xml\n\
+    \n\
+    # Start Traccar\n\
+    exec java -Xms512m -Xmx512m \
+    -cp "/opt/traccar/tracker-server.jar:/opt/traccar/lib/*" \
+    org.traccar.Main /opt/traccar/conf/traccar.xml' > $TRACCAR_HOME/start.sh && \
+    chmod +x $TRACCAR_HOME/start.sh
+
+# Expose web interface port
+EXPOSE 8082
+
+# Set working directory
+WORKDIR $TRACCAR_HOME
+
+# Start Traccar server
+CMD ["./start.sh"]

--- a/traccar-docker/docker-compose.yml
+++ b/traccar-docker/docker-compose.yml
@@ -1,0 +1,46 @@
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: traccar-mysql
+    environment:
+      MYSQL_DATABASE: traccar
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_ALLOW_EMPTY_PASSWORD: "no"
+    volumes:
+      - mysql-data:/var/lib/mysql
+      - ./schema:/docker-entrypoint-initdb.d
+    ports:
+      - "3306:3306"
+    command: >
+      --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --default-authentication-plugin=mysql_native_password --sql-mode=NO_ENGINE_SUBSTITUTION
+    healthcheck:
+      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-proot" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  traccar:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: traccar-server
+    environment:
+      - MYSQL_HOST=mysql
+      - MYSQL_DATABASE=traccar
+      - MYSQL_USER=root
+      - MYSQL_PASSWORD=root
+    ports:
+      - "8082:8082"
+    volumes:
+      - traccar-logs:/opt/traccar/logs
+      - traccar-data:/opt/traccar/data
+      - ./target/media:/opt/traccar/target/media
+      - ./traccar-web:/opt/traccar/traccar-web
+    depends_on:
+      mysql:
+        condition: service_healthy
+
+volumes:
+  mysql-data:
+  traccar-logs:
+  traccar-data:


### PR DESCRIPTION
- Installs openjdk:11 for the build environment and sets up the prerequisites
- Clones our forked Traccar repository from BunnyMan's account and initiates the build process with Gradle
- Uses debug.xml directly in the Dockerfile because mounting the file with Docker was unsuccessful; although not recommended, this approach works for now
- The compose file manages both the server and MySQL configuration setup
**- Should reduce the need for depending on people who already have traccar setup on their computer**